### PR TITLE
wb and unit buffer

### DIFF
--- a/src/BranchUnit.java
+++ b/src/BranchUnit.java
@@ -1,13 +1,16 @@
 public class BranchUnit extends Unit {
 
-    public BranchUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.BU);
+    public BranchUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.BU, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
+
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.BU);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/FPAddUnit.java
+++ b/src/FPAddUnit.java
@@ -1,13 +1,16 @@
 public class FPAddUnit extends Unit {
 
-    public FPAddUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.FPADD);
+    public FPAddUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.FPADD, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
+
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.FPADD);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/FPDivUnit.java
+++ b/src/FPDivUnit.java
@@ -1,13 +1,16 @@
 public class FPDivUnit extends Unit {
 
-    public FPDivUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.FPDIV);
+    public FPDivUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.FPDIV, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
+
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.FPDIV);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/FPMultUnit.java
+++ b/src/FPMultUnit.java
@@ -1,13 +1,16 @@
 public class FPMultUnit extends Unit {
 
-    public FPMultUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.FPMULT);
+    public FPMultUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.FPMULT, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
+
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.FPMULT);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/IntUnit.java
+++ b/src/IntUnit.java
@@ -1,13 +1,16 @@
 public class IntUnit extends Unit {
 
-    public IntUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.INT);
+    public IntUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.INT, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
+
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.INT);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/LoadStoreUnit.java
+++ b/src/LoadStoreUnit.java
@@ -1,13 +1,15 @@
 public class LoadStoreUnit extends Unit {
 
-    public LoadStoreUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.LOADSTORE);
+    public LoadStoreUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.LOADSTORE, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.LOADSTORE);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/MultUnit.java
+++ b/src/MultUnit.java
@@ -1,13 +1,16 @@
 public class MultUnit extends Unit {
 
-    public MultUnit(int numReservStation, int latency) {
-        super(numReservStation, latency, UnitName.MULT);
+    public MultUnit(int numReservStation, int latency, WB wb) {
+        super(numReservStation, latency, UnitName.MULT, wb);
     }
 
     @Override
     public void doCycle() {
+        if(shouldStall()) return;
+
         Instruction readyInstruction = ReservationStationStatusTable.getNextReadyInstruction(UnitName.MULT);
         Instruction finishedInstruction = shiftPipelineRight(readyInstruction);
         finishedInstruction.dest_reg_value = new Double(123123); // Would have to change this
+        moveToWBOrBuffer(finishedInstruction);
     }
 }

--- a/src/ReservationStationStatusTable.java
+++ b/src/ReservationStationStatusTable.java
@@ -46,9 +46,8 @@ public final class ReservationStationStatusTable {
         // TO DO: Whenever a value is obtained from the CDB, we can update our stations
     }
 
-    public static boolean isReservationStationFull() {
-        // TO DO:
-        return false;
+    public static boolean isReservationStationFull(UnitName unitName) {
+        return stationMap.get(unitName).size() == stationSizeMap.get(unitName).intValue();
     }
     
 }

--- a/src/Unit.java
+++ b/src/Unit.java
@@ -2,18 +2,23 @@ public abstract class Unit {
 
     private final int latency;
     private Instruction[] pipeline;
+    private Instruction buffer; 
+    private WB wb;
 
-    public Unit(int numReservStation, final int latency, UnitName unitName) {
+    public Unit(int numReservStation, final int latency, UnitName unitName, WB wb) 
+    {
         ReservationStationStatusTable.createStations(unitName, numReservStation);
         this.latency = latency;
         this.pipeline = new Instruction[latency];
+        this.wb = wb;
     }
 
     public void addInstruction(Instruction i) {
             // TODO Auto-generated method stub
     }
 
-    public Instruction shiftPipelineRight(Instruction instruction) {
+    public Instruction shiftPipelineRight(Instruction instruction) 
+    {
         Instruction finishedInstruction = null;
 
         if(this.pipeline[this.pipeline.length - 1] != null) {
@@ -27,6 +32,25 @@ public abstract class Unit {
         this.pipeline[0] = instruction;
 
         return finishedInstruction;
+    }
+
+    public boolean shouldStall()
+    {
+        return this.pipeline[this.pipeline.length - 1] != null && this.buffer != null && wb.isFull();
+    }
+
+    public void moveToWBOrBuffer(Instruction i)
+    {
+        if(!wb.isFull()) {
+            if(this.buffer != null){
+                wb.push(this.buffer);
+                this.buffer = i;
+            }else if(i != null){
+                wb.push(i);
+            }
+        }else{
+            this.buffer = i;
+        }
     }
 
     public abstract void doCycle();

--- a/src/WB.java
+++ b/src/WB.java
@@ -1,0 +1,40 @@
+import java.util.ArrayList;
+
+public class WB
+{
+    // private ROB rob;
+    private int maxPushSize;
+    private int numPushed;
+
+    // public WB(final ROB rob, int maxPushSize){} ---> Please delete the method signature below when we have ROB
+    public WB(int maxPushSize)
+    {
+        // this.rob = rob;
+        this.maxPushSize = maxPushSize;
+        this.numPushed = 0;
+    }
+
+    public boolean isFull() 
+    {
+        // I dont think the WB can ever be bottlenecked by the ROB.
+        // If the ROB does not have room, it doesnt matter to the WB
+        // as the instructions that it is attempting to give to ROB already
+        // has a reserved spot. The WB will never stall unless its maxPushSize = 0
+        
+        return numPushed < maxPushSize; 
+    }
+
+    public void push(Instruction i)
+    {
+        //boolean CDBSuccess = CDB.push(i); ---> Please delete CDBSuccess below when we have CDB
+        boolean CDBSuccess = false;
+
+        if (!CDBSuccess) System.out.println("Something went wrong... this should never happen");
+
+        //ROB.push(i); // TO-DO
+        numPushed +=1;
+
+    }
+
+
+}

--- a/src/WB.java
+++ b/src/WB.java
@@ -36,5 +36,15 @@ public class WB
 
     }
 
+    public void reset()
+    {
+        numPushed = 0;
+    }
+
+    public void setNewPushLimit(int newLimit)
+    {
+        this.maxPushSize = newLimit;
+    }
+
 
 }


### PR DESCRIPTION
Small Merge. 

I have added a WB class so that whenever an instruction has finished executing, it will be moved into the WB stage and immediately gets pushed through the CDB as well as being sent to the ROB.
If the WB stage is full and if there is a buffer that is free, the instruction would be stored in the buffer instead and hope that the WB will pick it up the next time. If it doesn't and if there is another instruction that needs the buffer, it will stall (there is a logic that checks for that). 

What still needs to be done will be the CDB and the ROB accepting values from WB. 

NOTE: WB.reset() has to be called in every iteration so that the number of items pushed back through the CDB can be reset back to zero. 

SUB NOTE: All files were compiled successfully at this current branch.